### PR TITLE
Fix error due to the changes in the np.load signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Alternatively, you can get Python and the libraries from other places.
 In this case, you need Python 3.6.3, NumPy 1.13.3, SciPy 0.19.1, and Matplotlib
 2.1.0, which can be installed in a `conda` environment with the command
 
-    conda create -n ficketmodel-reproducibility \
+    conda create -n fickettmodel-reproducibility \
         "python==3.6.3" \
         "numpy==1.13.3" \
         "scipy==0.19.1" \

--- a/bifurcation-diagram/lib_bifdiag.py
+++ b/bifurcation-diagram/lib_bifdiag.py
@@ -55,7 +55,7 @@ def get_simulation_data(params):
 
     # If there is cache file with simulation data, then use data from it.
     if os.path.isfile(cache_file):
-        with np.load(cache_file) as data:
+        with np.load(cache_file, allow_pickle=True) as data:
             theta = data['theta']
             D = data['D']
 
@@ -136,7 +136,7 @@ def save_bifurcation_data(bif_data, params):
 
 def load_bifurcation_data(params):
     cache_file = get_bif_data_filename(params)
-    with np.load(cache_file) as data:
+    with np.load(cache_file, allow_pickle=True) as data:
         theta = data['theta']
         extrema = data['extrema']
 


### PR DESCRIPTION
Default value of the parameter `allow_pickle` has been changed from True to False, so that now I need to pass it explicitly, otherwise npy files are loaded with errors.